### PR TITLE
Updating path search

### DIFF
--- a/src/Templates/AnalyzeTemplateCommand.cs
+++ b/src/Templates/AnalyzeTemplateCommand.cs
@@ -50,7 +50,7 @@ namespace Templates {
 
                         foreach(var f in folders) {
                             // finding folders under f that has a .template.config folder
-                            var foundDirs = Directory.GetDirectories(f,".template.config",new EnumerationOptions{RecurseSubdirectories = true });
+                            var foundDirs = Directory.GetDirectories(f,".template.config",new EnumerationOptions{RecurseSubdirectories = true, ReturnSpecialDirectories = true });
                             if(foundDirs == null || foundDirs.Length <= 0) {
                                 _reporter.WriteLine($"ERROR: No templates found under path '{f}'");
                             }


### PR DESCRIPTION
This accounts for "." directories on both Windows and Linux (currently fails if you say `analyze -f .` on Linux)