### PR TITLE
Update analyzer path check

### DIFF
--- a/src/Templates/AnalyzeTemplateCommand.cs
+++ b/src/Templates/AnalyzeTemplateCommand.cs
@@ -50,7 +50,7 @@ namespace Templates {
 
                         foreach(var f in folders) {
                             // finding folders under f that has a .template.config folder
-                            var foundDirs = Directory.GetDirectories(f,".template.config",new EnumerationOptions{RecurseSubdirectories = true });
+                            var foundDirs = Directory.GetDirectories(f,".template.config",new EnumerationOptions{RecurseSubdirectories = true, AttributesToSkip = FileAttributes.System });
                             if(foundDirs == null || foundDirs.Length <= 0) {
                                 _reporter.WriteLine($"ERROR: No templates found under path '{f}'");
                             }


### PR DESCRIPTION
Adding resetting the folders to check to allow you to set "." as a path to look for.  This resolves for Linux where folders that start with "." are considered hidden