### PR TITLE
Adding exit code to template analyze command

### DIFF
--- a/src/Templates/AnalyzeTemplateCommand.cs
+++ b/src/Templates/AnalyzeTemplateCommand.cs
@@ -48,6 +48,7 @@ namespace Templates {
                             $"folders: {string.Join(',',folders)}" :
                             "folders is null");
 
+                        bool foundIssues = false;
                         foreach(var f in folders) {
                             // finding folders under f that has a .template.config folder
                             var foundDirs = Directory.GetDirectories(f,".template.config",new EnumerationOptions{RecurseSubdirectories = true });
@@ -55,11 +56,11 @@ namespace Templates {
                                 _reporter.WriteLine($"ERROR: No templates found under path '{f}'");
                             }
                             foreach(var fd in foundDirs) {
-                                _templateAnalyzer.Analyze(Directory.GetParent(fd).FullName);
+                                foundIssues = _templateAnalyzer.Analyze(Directory.GetParent(fd).FullName) || foundIssues;
                             }
-
-                            //_templateAnalyzer.Analyze(f);
                         }
+
+                        return foundIssues ? -1 : 0;
                 }),
                 OptionPackages(),
                 OptionFolders(),

--- a/src/TemplatesShared/ITemplateAnalyzer.cs
+++ b/src/TemplatesShared/ITemplateAnalyzer.cs
@@ -1,5 +1,5 @@
 ﻿namespace TemplatesShared {
     public interface ITemplateAnalyzer {
-        void Analyze(string templateFolder);
+        bool Analyze(string templateFolder);
     }
 }

--- a/src/TemplatesShared/TemplateAnalyzer.cs
+++ b/src/TemplatesShared/TemplateAnalyzer.cs
@@ -33,7 +33,10 @@ namespace TemplatesShared {
         private IReporter _reporter;
         private IJsonHelper _jsonHelper;
 
-        public void Analyze(string templateFolder) {
+        /// <summary>
+        /// Returns true if issues are found, and false otherwise.
+        /// </summary>
+        public bool Analyze(string templateFolder) {
             Debug.Assert(!string.IsNullOrEmpty(templateFolder));
             _reporter.WriteLine();
             WriteMessage($@"Validating '{templateFolder}\.template.config\template.json'");
@@ -43,14 +46,14 @@ namespace TemplatesShared {
             if (!Directory.Exists(templateFolder)) {
                 // _reporter.WriteLine($"ERROR: templateFolder not found at '{templateFolder}'", indentPrefix);
                 WriteError($"ERROR: templateFolder not found at '{templateFolder}'", _outputPrefix);
-                return;
+                return true;
             }
 
             var templateJsonFile = Path.Combine(templateFolder, ".template.config/template.json");
             if (!File.Exists(templateJsonFile)) {
                 // _reporter.WriteLine($"template.json not found at '{templateJsonFile}'", indentPrefix);
                 WriteError($"template.json not found at '{templateJsonFile}'", _outputPrefix);
-                return;
+                return true;
             }
 
             JToken template;
@@ -60,7 +63,7 @@ namespace TemplatesShared {
             catch(Exception ex) {
                 // TODO: make exception more specific
                 WriteError($"Unable to load template from: '{templateJsonFile}'.\n Error: {ex.ToString()}");
-                return;
+                return true;
             }
 
             var foundIssues = false;
@@ -86,6 +89,8 @@ namespace TemplatesShared {
             if (!foundIssues) {
                 _reporter.WriteLine("√ no issues found", indentPrefix);
             }
+
+            return foundIssues;
         }
 
         private List<JTokenAnalyzeRule> GetRules() {


### PR DESCRIPTION
Added an exit code for the template analyze command. 

Return values:
`-1` => Issues found
`0` => No issues found